### PR TITLE
update mathjax cdn link

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -10,7 +10,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/highlight.min.js" integrity="sha256-+bhVTaRmJ/c07eV80nU8gD2cBBF0rYkf1txqXlrbvb0=" crossorigin="anonymous"></script>
 {{ range .Site.Params.highlight.languages }}
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.11.0/languages/{{ . }}.min.js"></script>
-<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js"></script>
 {{ end }}
 <script>hljs.initHighlightingOnLoad();</script>
 {{ if .Site.GoogleAnalytics }}


### PR DESCRIPTION
Because [MathJax CDN shutting down on April 30, 2017.](https://www.mathjax.org/cdn-shutting-down/)

I update the cdn link from `cdn.mathjax.org` to `cdnjs.cloudflare.com`. So there won't be a warning form Chrome.
![image](https://user-images.githubusercontent.com/4649294/27534498-c136867c-5a99-11e7-8eca-626a5425ea8e.png)
