### PR TITLE
other pages in navigation bar

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -3,6 +3,13 @@
     <nav class="nav">
       <div class="nav-left">
         <a class="nav-item" href="{{ .Site.BaseURL }}"><h1 class="title is-4">{{ .Site.Title }}</h1></a>
+      <nav class="nav-item level is-mobile">
+          {{ range .Site.Params.static_pages }}
+          <a class="level-item" href="{{ .url }}" target="_blank">
+            {{ .tag }}
+          </a>
+          {{ end }}
+        </nav>
       </div>
       <div class="nav-right">
         <nav class="nav-item level is-mobile">


### PR DESCRIPTION
Make it possible to place a link to /about/ or /home/ next to the Hu|core text.